### PR TITLE
Change behavior to send cert via event bus

### DIFF
--- a/vault_pki.py
+++ b/vault_pki.py
@@ -83,6 +83,7 @@ FULLCHAIN_FILENAME = 'fullchain.pem'
 CERT_VALIDITY_PERIOD = '{:d}h'.format(30 * 24)
 
 SALT_MASTER_CONFIG = '/etc/salt/master'
+SOCK_DIR = '/var/run/salt/master'
 
 default_level = logging.INFO
 log = logging.getLogger(__file__)
@@ -200,7 +201,7 @@ def _get_vault_connection(config):
 
 
 def _send_certs_to_minion(fqdn, dest_path, cert_data):
-    sock_dir = '/var/run/salt/master'
+    sock_dir = SOCK_DIR
     cert_path = os.path.join(dest_path, CERT_FILENAME)
     fullchain_path = os.path.join(dest_path, FULLCHAIN_FILENAME)
     cert = cert_data['certificate']


### PR DESCRIPTION
This set of changes works to move responsibility of writing
certificates from the Salt Reactor system to the requesting
application. To accomplish this, the response containing the
signed certificate is sent back via the Event bus to the minion
requesting a certificate.

This is a hack, make no doubt, but there is not a clean way to
call a salt module like this via Python. Or maybe there is and
I was not able to find documentation. The road I was going down
was to assemble a salt.util.event.MasterEvent payload, but I could
not get the minion to receieve events. Only with this call via
the CLI, so we're spawning to do the needful

Accompanies https://github.com/ripple/vault-pki-formula/pull/1